### PR TITLE
IntelliJ 2024.3 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,7 @@ repositories {
 
 dependencies {
   intellijPlatform {
-    intellijIdeaCommunity("2024.2")
-    instrumentationTools()
+    intellijIdeaCommunity("2024.3")
     bundledPlugin("com.intellij.java")
     testFramework(TestFrameworkType.Platform)
   }
@@ -24,13 +23,13 @@ dependencies {
 
 plugins {
   id("java")
-  id("org.jetbrains.intellij.platform") version "2.0.0"
+  id("org.jetbrains.intellij.platform") version "2.2.1"
   id("org.jetbrains.grammarkit") version "2022.3.2.2"
 }
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 03 20:08:55 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Added Support for IntelliJ 2024.3
* Upgraded IntelliJ Platform from 2.0.0 to 2.2.1
* Upgraded Gradle Distribution from 8.5 to 8.12