### PR TITLE
IntelliJ 2025.1 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   intellijPlatform {
-    intellijIdeaCommunity("2024.3")
+    intellijIdeaCommunity("2025.1")
     bundledPlugin("com.intellij.java")
     testFramework(TestFrameworkType.Platform)
   }
@@ -23,7 +23,7 @@ dependencies {
 
 plugins {
   id("java")
-  id("org.jetbrains.intellij.platform") version "2.2.1"
+  id("org.jetbrains.intellij.platform") version "2.5.0"
   id("org.jetbrains.grammarkit") version "2022.3.2.2"
 }
 
@@ -35,7 +35,7 @@ java {
 
 intellijPlatform {
   pluginConfiguration {
-    version = "1.6"
+    version = "1.6.2"
     name = "k"
   }
   buildSearchableOptions = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 03 20:08:55 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>idea.k3</id>
   <name>k3</name>
-  <version>1.6</version>
+  <version>1.6.2</version>
   <category>Custom Languages</category>
   <vendor email="antonio.andrade@me.com">Antonio Andrade</vendor>
   <description><![CDATA[


### PR DESCRIPTION
* Added support for IntelliJ 2025.1
* Upgraded IntelliJ Platform Gradle Plugin to 2.5.0
* Upgraded Gradle to 8.13