### PR TITLE
IntelliJ 2025.2 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   intellijPlatform {
-    intellijIdeaCommunity("2025.1")
+    intellijIdeaCommunity("2025.2")
     bundledPlugin("com.intellij.java")
     testFramework(TestFrameworkType.Platform)
   }
@@ -23,7 +23,7 @@ dependencies {
 
 plugins {
   id("java")
-  id("org.jetbrains.intellij.platform") version "2.6.0"
+  id("org.jetbrains.intellij.platform") version "2.7.1"
   id("org.jetbrains.grammarkit") version "2022.3.2.2"
 }
 
@@ -35,7 +35,7 @@ java {
 
 intellijPlatform {
   pluginConfiguration {
-    version = "1.6.2"
+    version = "1.6.3"
     name = "k"
   }
   buildSearchableOptions = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>idea.k3</id>
   <name>k3</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <category>Custom Languages</category>
   <vendor email="antonio.andrade@me.com">Antonio Andrade</vendor>
   <description><![CDATA[


### PR DESCRIPTION
* Added Support for IntelliJ 2025.2
* Upgraded IntelliJ Platform Gradle Plugin to v2.7.1
* Upgraded Gradle to v9.0.0